### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @moose-byte @awang8 @inuwan


### PR DESCRIPTION
A new CODEOWNERS file has been added to the .github directory. This file assigns the users @moose-byte, @awang8 and @inuwan as the default reviewers for all future code changes in this repository.