### PR TITLE
Add new user to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @moose-byte @awang8 @inuwan
+* @moose-byte @awang8 @inuwan @tsipporahc


### PR DESCRIPTION
You can see that the CODEOWNERS file under the .github directory has been updated. The user @tsipporahc has now been added as one of the code owners, joining @moose-byte, @awang8, and @inuwan