### PR TITLE
add static page for google search console verification

### DIFF
--- a/google167b18f51643ed7d.html
+++ b/google167b18f51643ed7d.html
@@ -1,1 +1,0 @@
-google-site-verification: google167b18f51643ed7d.html

--- a/src/templates/googleSiteVerification.tsx
+++ b/src/templates/googleSiteVerification.tsx
@@ -1,0 +1,25 @@
+import type {
+    TemplateProps,
+    TemplateRenderProps,
+    GetPath,
+    Template,
+    TemplateConfig,
+} from "@yext/pages";
+
+export const config: TemplateConfig = {
+    // The name of the feature. If not set the name of this file will be used (without extension).
+    // Use this when you need to override the feature name.
+    name: "google167b18f51643ed7d.html",
+};
+
+// The path must be exactly google167b18f51643ed7d.html
+export const getPath: GetPath<TemplateProps> = () => {
+    return "google167b18f51643ed7d.html";
+};
+
+const GoogleSiteVerification: Template<TemplateRenderProps> = () => {
+
+    return `google-site-verification: google167b18f51643ed7d.html`
+};
+
+export default GoogleSiteVerification;


### PR DESCRIPTION
This PR is to add a static route to pros.tt to support the google search console verification. 
We want to host this page at pros.tt/[google-code].html

<img width="1775" alt="2024-04-24_12-49-37" src="https://github.com/ttverifiedpro/itvp-pro-website/assets/108134941/64667284-81d0-4960-9d24-9835c25e3f2d">
