### PR TITLE
feat(FTPP-587): add global site map index, update footer links

### DIFF
--- a/src/components/indpro/Footer.tsx
+++ b/src/components/indpro/Footer.tsx
@@ -58,7 +58,7 @@ const Footer: React.FC<FooterGlobalProps> = (props: FooterGlobalProps) => {
         <div className={"flex flex-wrap gap-5 justify-between"}>
           <B2 className={"flex flex-wrap gap-5"}>
             <FooterLink href={"/store-finder"}>Store Finder</FooterLink>
-            <FooterLink href={"/expert-profile-sitemap.xml"}>Sitemap</FooterLink>
+            <FooterLink href={"/sitemap.xml"}>Sitemap</FooterLink>
           </B2>
           <div className={"flex flex-wrap space-x-5"}>
             <YouTube />
@@ -121,7 +121,7 @@ const Footer: React.FC<FooterGlobalProps> = (props: FooterGlobalProps) => {
           </div>
 
           <div className={"flex flex-col s:flex-row gap-4"}>
-            <ul className={"flex flex-wrap s:block s:columns-2 s:w-[275px]"}>
+            <ul className={"flex flex-wrap s:block s:w-[275px]"}>
               <FooterListLink href={"https://www.intuit.com/company/"} text={"About Intuit"} />
               <FooterListLink href={"https://www.intuit.com/careers/"} text={"Join Our Team"} />
               <FooterListLink href={"https://www.intuit.com/company/press-room/"} text={"Press"} />
@@ -139,6 +139,14 @@ const Footer: React.FC<FooterGlobalProps> = (props: FooterGlobalProps) => {
               <FooterListLink
                 href={"https://www.intuit.com/accessibility/"}
                 text={"Accessibility"}
+              />
+              <FooterListLink
+                  href={"https://pros.turbotax.intuit.com/full-service-experts/directory"}
+                  text={"Find a TurboTax Live Full Service expert"}
+              />
+              <FooterListLink
+                  href={"https://pros.turbotax.intuit.com/local-tax-experts"}
+                  text={"Find a Verified Tax Professional near you"}
               />
             </ul>
 
@@ -260,7 +268,7 @@ const ProductLogo: React.FC<{ href: string; name: string; image: string; width: 
 const FooterListLink: React.FC<{ href: string; text: string }> = ({ href, text }) => {
   return (
     <li
-      className={`mb-2 s:max-w-[130px] text-2 after:content-['|'] after:px-2 after:last:content-none after:last:px-0 s:after:content-none s:after:px-0`}
+      className={`mb-2 text-2 after:content-['|'] after:px-2 after:last:content-none after:last:px-0 s:after:content-none s:after:px-0`}
     >
       <FooterLink href={href}>{text}</FooterLink>
     </li>

--- a/src/templates/robots.ts
+++ b/src/templates/robots.ts
@@ -24,6 +24,6 @@ export const getPath: GetPath<TemplateProps> = () => {
 export const render = (data: TemplateRenderProps) => {
   return `User-agent: *
 Disallow:
-Sitemap: https://pros.turbotax.intuit.com/expert-profile-sitemap.xml
+Sitemap: https://pros.turbotax.intuit.com/sitemap.xml
 `;
 };

--- a/src/templates/sitemap.tsx
+++ b/src/templates/sitemap.tsx
@@ -1,0 +1,35 @@
+import type {
+    TemplateProps,
+    TemplateRenderProps,
+    GetPath,
+    TemplateConfig,
+} from "@yext/pages";
+
+export const config: TemplateConfig = {
+    // The name of the feature. If not set the name of this file will be used (without extension).
+    // Use this when you need to override the feature name.
+    name: "sitemap.xml",
+};
+
+/**
+ * Defines the path that the generated file will live at for production.
+ *
+ * NOTE: This currently has no impact on the local dev path. Local dev urls currently
+ * take on the form: featureName/entityId
+ */
+export const getPath: GetPath<TemplateProps> = () => {
+    return `sitemap.xml`;
+};
+
+export const render = (data: TemplateRenderProps) => {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+  <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://pros.turbotax.intuit.com/expert-profile-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://pros.turbotax.intuit.com/full-service-experts/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>
+`;
+};

--- a/src/types/autogen.ts
+++ b/src/types/autogen.ts
@@ -1,18 +1,19 @@
-export interface Address {
-	line1?: string,
-	line2?: string,
-	line3?: string,
-	sublocality?: string,
-	city?: string,
-	region?: string,
-	postalCode?: string,
-	extraDescription?: string,
-	countryCode?: string,
+export interface C_meta {
+	title?: string,
+	description?: string,
 }
 
-export interface Coordinate {
-	latitude?: number,
-	longitude?: number,
+export enum LinkType {
+	OTHER = "Other",
+	URL = "URL",
+	PHONE = "Phone",
+	EMAIL = "Email",
+}
+
+export interface C_findAVerifiedPro {
+	label?: string,
+	linkType?: LinkType,
+	link?: string,
 }
 
 export interface ImageThumbnail {
@@ -27,6 +28,104 @@ export interface Image {
 	height: number,
 	thumbnails?: ImageThumbnail[],
 	alternateText?: string,
+}
+
+export interface Address {
+	line1?: string,
+	line2?: string,
+	line3?: string,
+	sublocality?: string,
+	city?: string,
+	region?: string,
+	postalCode?: string,
+	extraDescription?: string,
+	countryCode?: string,
+}
+
+export interface Dm_directoryChildren {
+	slug?: string,
+	name?: string,
+	address?: Address,
+	addressHidden?: boolean,
+	headshot?: Image,
+	mainPhone?: any,
+	c_taxProName?: string,
+	googlePlaceId?: string,
+	c_tagline?: string,
+	dm_baseEntityCount?: string,
+	dm_directoryChildren?: any,
+}
+
+export interface Dm_directoryParents_directory {
+	slug?: string,
+	name?: string,
+}
+
+export interface DirectoryCity {
+	id: string,
+	uid: string,
+	name: string,
+	slug: string,
+	c_meta: C_meta,
+	c_heroTitle: string,
+	c_heroDescription: string,
+	c_findAVerifiedPro: C_findAVerifiedPro,
+	c_findAVerifiedProHeroText: string,
+	c_directoryHeroImage: Image,
+	c_onrampCTAURL: string,
+	dm_directoryChildren: Dm_directoryChildren[],
+	dm_directoryParents_directory: Dm_directoryParents_directory[],
+}
+
+export interface Dm_directoryChildren_1 {
+	slug?: string,
+	name?: string,
+	dm_baseEntityCount?: string,
+	dm_directoryChildren?: any,
+}
+
+export interface DirectoryRegion {
+	id: string,
+	uid: string,
+	name: string,
+	slug: string,
+	c_meta: C_meta,
+	c_heroTitle: string,
+	c_heroDescription: string,
+	c_findAVerifiedPro: C_findAVerifiedPro,
+	c_findAVerifiedProHeroText: string,
+	c_directoryHeroImage: Image,
+	c_onrampCTAURL: string,
+	dm_directoryChildren: Dm_directoryChildren_1[],
+	dm_directoryParents_directory: Dm_directoryParents_directory[],
+}
+
+export interface Dm_directoryChildren_2 {
+	slug?: string,
+	name?: string,
+	dm_baseEntityCount?: string,
+	dm_directoryChildren?: any,
+}
+
+export interface DirectoryRoot {
+	id: string,
+	uid: string,
+	name: string,
+	slug: string,
+	c_meta: C_meta,
+	c_heroTitle: string,
+	c_heroDescription: string,
+	c_findAVerifiedPro: C_findAVerifiedPro,
+	c_findAVerifiedProHeroText: string,
+	c_directoryHeroImage: Image,
+	c_onrampCTAURL: string,
+	dm_directoryChildren: Dm_directoryChildren_2[],
+	dm_directoryParents_directory: Dm_directoryParents_directory[],
+}
+
+export interface Coordinate {
+	latitude?: number,
+	longitude?: number,
 }
 
 export interface Interval {


### PR DESCRIPTION
This PR includes the following changes to support the XML site map and seoptimization work:

**1. add global site map index**
<img width="777" alt="2024-09-24_12-06-45" src="https://github.com/user-attachments/assets/7dc0bce1-329d-4355-b897-35f83d840c8b">

**2. update robots.ts**
<img width="474" alt="2024-09-24_12-08-38" src="https://github.com/user-attachments/assets/f727ee25-f9fc-4549-a2f2-c8cc3d345572">

**3. update footer links**
<img width="1287" alt="2024-09-24_12-05-47" src="https://github.com/user-attachments/assets/4819e7af-b97c-4131-85dc-4128745a0f22">

